### PR TITLE
[WB-765] Update Telestream gem to remove call to `URI.escape`

### DIFF
--- a/flip/Gemfile
+++ b/flip/Gemfile
@@ -3,5 +3,6 @@ source 'https://rubygems.org'
 gemspec
 
 group :development, :test do
+  gem 'addressable', '~> 2.8'
   gem 'rake', '~> 12.0.0'
 end

--- a/flip/lib/telestream_cloud_flip/api_client.rb
+++ b/flip/lib/telestream_cloud_flip/api_client.rb
@@ -10,12 +10,12 @@ Swagger Codegen version: 2.3.1
 
 =end
 
+require 'addressable'
 require 'date'
 require 'json'
 require 'logger'
 require 'tempfile'
 require 'typhoeus'
-require 'uri'
 
 module TelestreamCloud::Flip
   class ApiClient
@@ -264,7 +264,7 @@ module TelestreamCloud::Flip
     def build_request_url(path)
       # Add leading and trailing slashes to path
       path = "/#{path}".gsub(/\/+/, '/')
-      URI.encode(@config.base_url + path)
+      Addressable::URI.encode(@config.base_url + path)
     end
 
     # Builds the HTTP request body

--- a/flip/lib/telestream_cloud_flip/configuration.rb
+++ b/flip/lib/telestream_cloud_flip/configuration.rb
@@ -10,7 +10,7 @@ Swagger Codegen version: 2.3.1
 
 =end
 
-require 'uri'
+require 'addressable'
 
 module TelestreamCloud::Flip
   class Configuration
@@ -175,7 +175,7 @@ module TelestreamCloud::Flip
 
     def base_url
       url = "#{scheme}://#{[host, base_path].join('/').gsub(/\/+/, '/')}".sub(/\/+\z/, '')
-      URI.encode(url)
+      Addressable::URI.encode(url)
     end
 
     # Gets API key (with prefix if set).

--- a/telestream_cloud.gemspec
+++ b/telestream_cloud.gemspec
@@ -13,9 +13,9 @@ Gem::Specification.new do |s|
   s.description = %q{Telestream Cloud SDK}
 
   s.add_dependency 'addressable', '~> 2.8'
-  s.add_dependency "telestream_cloud_flip", "2.0.0"
-  s.add_dependency "telestream_cloud_tts", "2.0.0"
-  s.add_dependency "telestream_cloud_qc", "2.0.0"
+  s.add_dependency "telestream_cloud_flip", "2.0.1"
+  s.add_dependency "telestream_cloud_tts", "2.0.1"
+  s.add_dependency "telestream_cloud_qc", "2.0.4"
 
   s.rubyforge_project = "telestream_cloud"
 

--- a/telestream_cloud.gemspec
+++ b/telestream_cloud.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |s|
   s.summary     = %q{Telestream Cloud SDK}
   s.description = %q{Telestream Cloud SDK}
 
+  s.add_dependency 'addressable', '~> 2.8'
   s.add_dependency "telestream_cloud_flip", "2.0.0"
   s.add_dependency "telestream_cloud_tts", "2.0.0"
   s.add_dependency "telestream_cloud_qc", "2.0.0"


### PR DESCRIPTION
See: [WB-765](https://within3.atlassian.net/browse/WB-765)

Because this is purely for use in Big Red and not really meant to upstream, I only updated the calls that we're using.